### PR TITLE
fix: avoid invalid ACP lock caused by mixed policy

### DIFF
--- a/docs/rc-lock.md
+++ b/docs/rc-lock.md
@@ -18,7 +18,7 @@
 | ----------- | -------------------------------------------------------------------- |
 | `code_hash` | `0x79f90bb5e892d80dd213439eeab551120eb417678824f282b4ffb5f21bad2e1e` |
 | `hash_type` | `type`                                                               |
-| `tx_hash`   | `0xaa8ab7e97ed6a268be5d7e26d63d115fa77230e51ae437fc532988dd0c3ce10a` |
+| `tx_hash`   | `0x9154df4f7336402114d04495175b37390ce86a4906d2d4001cf02c3e6d97f39c` |
 | `index`     | `0x0`                                                                |
 | `dep_type`  | `code`                                                               |
 

--- a/packages/ckit/src/predefined/lina.ts
+++ b/packages/ckit/src/predefined/lina.ts
@@ -27,7 +27,7 @@ export const SCRIPTS: CkitConfig['SCRIPTS'] = {
     INDEX: '0x',
     DEP_TYPE: 'code',
   },
-  // TODO replace me when deployed
+
   UNIPASS: {
     INDEX: '0x0',
     TX_HASH: '0x1a04142a2a745fb3b7e0e9b61241676c1c94ad8cdacb36f223661130a23fb007',
@@ -36,8 +36,6 @@ export const SCRIPTS: CkitConfig['SCRIPTS'] = {
     HASH_TYPE: 'type',
   },
 
-  // TODO deploy the rc lock to test chain
-  //  the config here is fake
   RC_LOCK: {
     CODE_HASH: '0x9f3aeaf2fc439549cbc870c653374943af96a0658bd6b51be8d8983183e6f52f',
     HASH_TYPE: 'type',


### PR DESCRIPTION
 to avoid invalid ACP lock caused by mixed `findAcp` policy and `createCapacity`