### PR TITLE
feat: migrate from bigint to jsbi

### DIFF
--- a/packages/base/src/typeid.ts
+++ b/packages/base/src/typeid.ts
@@ -13,10 +13,19 @@ function toArrayBuffer(buf: Uint8Array) {
   return ab;
 }
 
-function toBigUInt64LE(num: HexString | number | bigint) {
-  num = BigInt(num);
+function toBigUInt64LE(num: HexString | number | bigint): ArrayBuffer {
   const buf = toBuffer('', 8);
-  buf.writeBigUInt64LE(num);
+
+  if (typeof num === 'bigint') {
+    buf.writeBigUInt64LE(num);
+  } else if (Number.isSafeInteger(Number(num))) {
+    num = Number(num);
+    buf.writeUInt32LE(num & 0xffffffff, 0);
+    buf.writeUInt32LE((num >>> 32) & 0xffffffff, 4);
+  } else {
+    throw new Error(`invalid input ${num}`);
+  }
+
   return toArrayBuffer(buf);
 }
 

--- a/packages/ckit/package.json
+++ b/packages/ckit/package.json
@@ -12,7 +12,6 @@
   },
   "dependencies": {
     "@ckb-lumos/base": "^0.16.0",
-    "@ckb-lumos/common-scripts": "^0.16.0",
     "@ckb-lumos/config-manager": "^0.16.0",
     "@ckb-lumos/hd": "^0.16.0",
     "@ckb-lumos/helpers": "^0.16.0",
@@ -31,9 +30,13 @@
     "rxjs": "^7.3.0"
   },
   "devDependencies": {
+    "@ckb-lumos/common-scripts": "^0.16.0",
     "@ckitjs/tippy-client": "*",
     "@nervosnetwork/ckb-sdk-core": "^0.43.0",
     "@types/app-root-path": "^1.2.4",
     "app-root-path": "^3.0.0"
+  },
+  "peerDependencies": {
+    "jsbi": "^4.1.0"
   }
 }

--- a/packages/ckit/src/__tests__/secp256k1-sudt.spec.ts
+++ b/packages/ckit/src/__tests__/secp256k1-sudt.spec.ts
@@ -354,24 +354,24 @@ test('test find_acp_transfer_sudt with extra capacity supply', async () => {
   const recipient1Signer = provider.generateAcpSigner();
   const recipient2Signer = provider.generateAcpSigner();
   const recipient3Signer = provider.generateAcpSigner();
-  const recipient1Address = await recipient1Signer.getAddress();
-  const recipient2Address = await recipient2Signer.getAddress();
-  const recipient3Address = await recipient3Signer.getAddress();
-  const testUdt = provider.newSudtScript(await issuerSigner.getAddress());
+  const recipient1Address = recipient1Signer.getAddress();
+  const recipient2Address = recipient2Signer.getAddress();
+  const recipient3Address = recipient3Signer.getAddress();
+  const testUdt = provider.newSudtScript(issuerSigner.getAddress());
 
   const beforeBalance0 = await provider.getUdtBalance(recipient1Address, testUdt);
 
   eqAmount(beforeBalance0, 0);
 
   // transfer ckb to recipient2Address
-  debug(`start transfer %o`, { from: await issuerSigner.getAddress(), to: recipient2Address });
+  debug(`start transfer %o`, { from: issuerSigner.getAddress(), to: recipient2Address });
   const unsignedTransferCkbTx = await new TransferCkbBuilder(
     { recipients: [{ recipient: recipient2Address, amount: '1000000000000', capacityPolicy: 'createCell' }] },
     provider,
-    await issuerSigner.getAddress(),
+    issuerSigner.getAddress(),
   ).build();
   const signed = await issuerSigner.seal(unsignedTransferCkbTx);
-  const transferCkbTxHash = await provider.sendTxUntilCommitted(signed, { timeoutMs: 360000 });
+  const transferCkbTxHash = await provider.sendTxUntilCommitted(signed);
   debug(`end transfer ckb, %s`, transferCkbTxHash);
 
   const recipients: MintOptions['recipients'] = [

--- a/packages/ckit/src/helpers/Amount.ts
+++ b/packages/ckit/src/helpers/Amount.ts
@@ -6,7 +6,7 @@ export type HumanizeOptions = { decimalPlaces?: number; separator?: boolean; dec
 type AmountValue = BigNumber.Value | bigint;
 type AmountLike = AmountValue | Amount;
 
-function BN(val: AmountValue | Amount): BigNumber {
+export function BN(val: AmountValue | Amount): BigNumber {
   if (typeof val === 'bigint') return new BigNumber(String(val));
   if (Amount.checkIsAmount(val)) return new BigNumber(String(val));
   return new BigNumber(val);
@@ -35,7 +35,7 @@ export class Amount {
   static from(value: AmountValue, decimals = 0): Amount {
     if (decimals < 0 || !Number.isInteger(decimals)) boom('The decimal not valid');
 
-    if (typeof value === 'bigint') return new Amount(BN(value * 10n ** BigInt(decimals)));
+    if (typeof value === 'bigint') return new Amount(BN(value * BigInt(10) ** BigInt(decimals)));
     if (!decimals) return new Amount(BN(value));
 
     return new Amount(BN(value).times(BN(10).pow(decimals)));

--- a/packages/ckit/src/tx-builders/pw/MintSudtPwBuilder.ts
+++ b/packages/ckit/src/tx-builders/pw/MintSudtPwBuilder.ts
@@ -3,6 +3,7 @@ import { Amount, Builder, Cell, RawTransaction, Transaction } from '@lay2/pw-cor
 import { from, lastValueFrom, mergeMap, toArray } from 'rxjs';
 import { MintOptions } from '..';
 import { NoAvailableCellError } from '../../errors';
+import { BN } from '../../helpers';
 import { Pw } from '../../helpers/pw';
 import { CkitProvider } from '../../providers';
 import { byteLenOfCkbLiveCell, byteLenOfSudt } from '../builder-utils';
@@ -22,7 +23,7 @@ export class NonAcpPwMintBuilder extends AbstractPwSenderBuilder {
       .map((item) => {
         const recipientLockArgsBytesLen = (this.provider.parseToScript(item.recipient).args.length - 2) / 2;
         return new Cell(
-          new Amount(String(BigInt(item.additionalCapacity || 0)), 0).add(
+          new Amount(String(BN(item.additionalCapacity || 0)), 0).add(
             new Amount(String(byteLenOfSudt(recipientLockArgsBytesLen))),
           ),
           Pw.toPwScript(this.provider.parseToScript(item.recipient)), // recipient lock

--- a/packages/ckit/src/tx-builders/rc/CreateRcUdtInfoCellPwBuilder.ts
+++ b/packages/ckit/src/tx-builders/rc/CreateRcUdtInfoCellPwBuilder.ts
@@ -1,9 +1,10 @@
 import { utils } from '@ckb-lumos/base';
 import { formatByteLike } from '@ckitjs/easy-byte/dist';
-import { SerializeUdtInfo, RcSupplyOutputData } from '@ckitjs/rc-lock';
+import { SerializeUdtInfo, OmniSupplyOutputData } from '@ckitjs/rc-lock';
 import { bytes, invariant } from '@ckitjs/utils';
 import { Amount, Cell, RawTransaction, Transaction } from '@lay2/pw-core';
 import { Reader } from 'ckb-js-toolkit';
+import JSBI from 'jsbi';
 import { CkbAmount } from '../../helpers';
 import { Pw } from '../../helpers/pw';
 import { CkitProvider } from '../../providers';
@@ -68,10 +69,10 @@ export class CreateRcUdtInfoCellPwBuilder extends AbstractPwSenderBuilder {
       undefined,
       bytes.concat(
         formatByteLike(
-          RcSupplyOutputData.encode({
+          OmniSupplyOutputData.encode({
             version: 0,
-            current_supply: 0n,
-            max_supply: BigInt(sudtInfo.maxSupply),
+            current_supply: JSBI.BigInt(0),
+            max_supply: JSBI.BigInt(sudtInfo.maxSupply),
             sudt_script_hash: utils.computeScriptHash(provider.newSudtScript(Pw.fromPwScript(rcLockScript))),
           }),
         ),

--- a/packages/easy-byte/package.json
+++ b/packages/easy-byte/package.json
@@ -12,5 +12,8 @@
   },
   "dependencies": {
     "buffer": "^6.0.3"
+  },
+  "peerDependencies": {
+    "jsbi": "4.1.0"
   }
 }

--- a/packages/easy-byte/src/struct.spec.ts
+++ b/packages/easy-byte/src/struct.spec.ts
@@ -1,4 +1,18 @@
-import { createFixedStruct, U64LE, U8, U128LE, Field, U128BE, I128LE, I128BE } from './struct';
+import JSBI from 'jsbi';
+import {
+  createFixedStruct,
+  U64LE,
+  U8,
+  U128LE,
+  Field,
+  U128BE,
+  I128LE,
+  I128BE,
+  U64LEJSBI,
+  U128LEJSBI,
+  U128BEJSBI,
+  U64BEJSBI,
+} from './struct';
 
 function testReadAndWrite<T>(field: Field<T>, buffer: Buffer, x: T) {
   expect(field.read(buffer)).toEqual(x);
@@ -39,4 +53,26 @@ test('encoding and decoding should be correct', () => {
 
   const decoded = messageStruct.decode(bytes);
   expect(decoded).toEqual(struct);
+});
+
+test('encoding and decoding jsbi field', () => {
+  const codec = createFixedStruct()
+    .field('jsbi64le', U64LEJSBI)
+    .field('jsbi64be', U64BEJSBI)
+    .field('jsbi128le', U128LEJSBI)
+    .field('jsbi128be', U128BEJSBI);
+
+  const encoded = codec.encode({
+    jsbi64le: JSBI.BigInt('0x0102'),
+    jsbi64be: JSBI.BigInt('0x0102'),
+    jsbi128le: JSBI.BigInt('0x0102'),
+    jsbi128be: JSBI.BigInt('0x0102'),
+  });
+
+  expect(
+    Buffer.from(
+      '020100000000000000000000000001020201000000000000000000000000000000000000000000000000000000000102',
+      'hex',
+    ),
+  ).toEqual(encoded);
 });

--- a/packages/mercury-client/src/index.ts
+++ b/packages/mercury-client/src/index.ts
@@ -27,7 +27,7 @@ export interface ResolvedOutpoint {
   tx_index: HexNumber;
 }
 
-interface GetPayloadResponse {
+interface GetCellsResponse {
   last_cursor: HexString;
   objects: ResolvedOutpoint[];
 }
@@ -35,6 +35,11 @@ interface GetPayloadResponse {
 export interface GetTipResponse {
   block_hash: Hash;
   block_number: HexNumber;
+}
+
+interface GetTransactionResponse {
+  last_cursor: HexString;
+  objects: ResolvedOutpoint[];
 }
 
 export class MercuryClient {
@@ -45,7 +50,7 @@ export class MercuryClient {
     this.client = new Client(new RequestManager([transport]));
   }
 
-  get_cells(payload: GetCellsPayload): Promise<GetPayloadResponse> {
+  get_cells(payload: GetCellsPayload): Promise<GetCellsResponse> {
     const { search_key, order = 'asc', limit = '0x3e8' /*1_000*/, after_cursor } = payload;
     return this.client.request({
       method: 'get_cells',
@@ -55,5 +60,9 @@ export class MercuryClient {
 
   get_tip(): Promise<GetTipResponse> {
     return this.client.request({ method: 'get_tip' });
+  }
+
+  get_transactions(): Promise<GetTransactionResponse> {
+    return this.client.request({ method: 'get_transactions', params: [] });
   }
 }

--- a/packages/rc-lock/src/rc.ts
+++ b/packages/rc-lock/src/rc.ts
@@ -1,5 +1,14 @@
 import { Hash, HexNumber, HexString, Script, utils } from '@ckb-lumos/base';
-import { createField, createFixedStruct, Field, formatByteLike, toBuffer, U128LE, U8 } from '@ckitjs/easy-byte';
+import {
+  createField,
+  createFixedStruct,
+  Field,
+  formatByteLike,
+  toBuffer,
+  U128LE,
+  U128LEJSBI,
+  U8,
+} from '@ckitjs/easy-byte';
 import { MercuryClient, SearchKey, ResolvedOutpoint } from '@ckitjs/mercury-client';
 import { bytes } from '@ckitjs/utils';
 import { Reader } from 'ckb-js-toolkit';
@@ -30,10 +39,22 @@ export const RcIdentityLockArgs = createFixedStruct()
 
 export const RcSupplyLockArgs = RcIdentityLockArgs.field('type_id_hash', Bytes(32));
 
+export const OmniIdentityLockArgs = RcIdentityLockArgs;
+export const OmniSupplyLockArgs = RcSupplyLockArgs;
+
+/**
+ * @deprecated please migrate to {@link OmniSupplyOutputData}
+ */
 export const RcSupplyOutputData = createFixedStruct()
   .field('version', U8)
   .field('current_supply', U128LE)
   .field('max_supply', U128LE)
+  .field('sudt_script_hash', Bytes(32));
+
+export const OmniSupplyOutputData = createFixedStruct()
+  .field('version', U8)
+  .field('current_supply', U128LEJSBI)
+  .field('max_supply', U128LEJSBI)
   .field('sudt_script_hash', Bytes(32));
 
 /**
@@ -94,8 +115,8 @@ export interface RcHelperConfig {
 }
 
 export function convertToSudtSupplyInfo(outputData: HexString): SudtSupplyInfo {
-  const { current_supply, max_supply, version } = RcSupplyOutputData.decode(toBuffer(outputData));
-  const fixedDataLen = RcSupplyOutputData.fields.reduce((acc, field) => acc + field[1].byteWidth, 0);
+  const { current_supply, max_supply, version } = OmniSupplyOutputData.decode(toBuffer(outputData));
+  const fixedDataLen = OmniSupplyOutputData.fields.reduce((acc, field) => acc + field[1].byteWidth, 0);
   const udtInfo = new UdtInfo(new Reader(bytes.toHex(outputData.slice(2 /*0x*/ + fixedDataLen * 2))));
 
   return {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -12,5 +12,8 @@
   },
   "dependencies": {
     "tiny-invariant": "^1.1.0"
+  },
+  "peerDependencies": {
+    "jsbi": "4.1.0"
   }
 }


### PR DESCRIPTION
This PR replaces bigint with JSBI. We have found that some developers are having trouble with ckit in Safari on iOS13, due to earlier browsers not supporting the bigint feature. 
However, in order to maintain compatibility, ckit has kept the bigint input and added some new APIs to the original, which will be passed using JSBI


## New API

```ts
// previous bigint version
RcSupplyOutputData.encode({
  current_supply: 0n,
  max_supply: BigInt(sudtInfo.maxSupply)
})

// newest JSBI version
OmniSupplyOutputData.encode({
  current_supply: JSBI.BigInt(0),
  max_supply: JSBI.BigInt(sudtInfo.maxSupply),
})
```