### PR TITLE
feat(acpBuilder): give an option to allow duplicate recipients

### DIFF
--- a/packages/ckit/src/__tests__/secp256k1-sudt.spec.ts
+++ b/packages/ckit/src/__tests__/secp256k1-sudt.spec.ts
@@ -726,7 +726,19 @@ test('transfer CKB with spilit duplicate cell and sudt with acp', async () => {
     ),
   );
 
-  expect(await provider.collectUdtCells(recipient2.getAddress(), sudt, '0')).toHaveLength(1);
+  expect(
+    (
+      await provider.mercury.get_cells({
+        search_key: {
+          script: provider.parseToScript(recipient2.getAddress()),
+          script_type: 'lock',
+          filter: {
+            script: sudt,
+          },
+        },
+      })
+    ).objects,
+  ).toHaveLength(1);
 
   await provider.signAndSendTxUntilCommitted(
     recipient1,

--- a/packages/ckit/src/tx-builders/AcpTransferSudtBuilder.ts
+++ b/packages/ckit/src/tx-builders/AcpTransferSudtBuilder.ts
@@ -25,6 +25,7 @@ export interface RecipientOption {
 
 export interface TransferSudtOptions {
   recipients: RecipientOption[];
+  allowDuplicateRecipient?: boolean;
 }
 
 export class AcpTransferSudtBuilder extends AbstractTransactionBuilder {

--- a/packages/ckit/src/tx-builders/pw/TransferSudtPwBuilder.ts
+++ b/packages/ckit/src/tx-builders/pw/TransferSudtPwBuilder.ts
@@ -49,7 +49,9 @@ export class TransferSudtPwBuilder extends AbstractPwSenderBuilder {
     // 1. handle sudt cells
     for (const item of optionsGroupBySudt) {
       let [, optionsOfSameSudt] = item;
-      optionsOfSameSudt = this.deduplicateOptions(optionsOfSameSudt);
+      if (!this.options.allowDuplicateRecipient) {
+        optionsOfSameSudt = this.deduplicateOptions(optionsOfSameSudt);
+      }
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const sudtScript = optionsOfSameSudt[0]!.sudt;
       let totalTransferAmount = new Amount('0', 0);


### PR DESCRIPTION
To give an option for anyone who want to create multiple sUDT cells which have the same recipient address and the same type script.