### PR TITLE
refactor: change collect cell param to address

### DIFF
--- a/packages/base/src/AbstractProvider.ts
+++ b/packages/base/src/AbstractProvider.ts
@@ -122,15 +122,15 @@ export abstract class AbstractProvider implements Provider {
   abstract getChainInfo(): Promise<ChainInfo>;
   /**
    * @deprecated please migrate to {@link collectLockOnlyCells}
-   * @param lock
+   * @param address
    * @param capacity
    */
-  abstract collectCkbLiveCells(lock: Address, capacity: HexNumber): Promise<ResolvedOutpoint[]>;
+  abstract collectCkbLiveCells(address: Address, capacity: HexNumber): Promise<ResolvedOutpoint[]>;
   /**
    *
-   * @param lock
+   * @param address
    * @param capacity
    */
-  abstract collectLockOnlyCells(lock: Address, capacity: HexNumber): Promise<Cell[]>;
+  abstract collectLockOnlyCells(address: Address, capacity: HexNumber): Promise<Cell[]>;
   abstract sendTransaction(tx: Transaction): Promise<Hash>;
 }

--- a/packages/ckit/src/providers/mercury/MercuryProvider.ts
+++ b/packages/ckit/src/providers/mercury/MercuryProvider.ts
@@ -138,9 +138,9 @@ export class MercuryProvider extends AbstractProvider {
     return acc.cells;
   }
 
-  override async collectLockOnlyCells(lock: Address | Script, capacity: HexNumber): Promise<Cell[]> {
+  override async collectLockOnlyCells(fromInfo: Address | Script, capacity: HexNumber): Promise<Cell[]> {
     const result = await this.collectCkbLiveCells(
-      typeof lock === 'string' ? lock : this.parseToAddress(lock),
+      typeof fromInfo === 'string' ? fromInfo : this.parseToAddress(fromInfo),
       capacity,
     );
 


### PR DESCRIPTION
motivation: It is not honest when a function param named `lock` has a type of `string`.